### PR TITLE
Add tetris clear visual effect

### DIFF
--- a/lib/game/blocks.dart
+++ b/lib/game/blocks.dart
@@ -12,10 +12,12 @@ class BlcoksGame {
   double _accumulator = 0.0;
 
   VoidCallback? onUpdate;
+  final LinesClearedCallback? onTetris;
   bool isPaused = false;
   Duration _pauseAt = Duration.zero;
 
-  BlcoksGame(TickerProvider vsync, {this.onUpdate}) : grid = Grid() {
+  BlcoksGame(TickerProvider vsync, {this.onUpdate, this.onTetris})
+      : grid = Grid(onTetris: onTetris) {
     _ticker = vsync.createTicker(tick);
     _ticker.muted = false;
     _ticker.start();

--- a/lib/game/grid.dart
+++ b/lib/game/grid.dart
@@ -1,5 +1,8 @@
 import 'dart:math';
 
+/// Callback for tetris line clear events.
+typedef LinesClearedCallback = void Function(List<int> rows);
+
 import 'block.dart';
 import 'block_type.dart';
 
@@ -23,7 +26,9 @@ class Grid {
   bool gameOver = false;
   bool victory = false;
 
-  Grid() {
+  final LinesClearedCallback? onTetris;
+
+  Grid({this.onTetris}) {
     spawnBlock();
   }
 
@@ -73,10 +78,12 @@ class Grid {
 
   void clearLines() {
     int cleared = 0;
+    List<int> clearedRows = [];
     for (int y = 0; y < rows; y++) {
       if (cells[y].every((cell) => cell != null)) {
         cells.removeAt(y);
         cells.insert(0, List.filled(columns, null));
+        clearedRows.add(y);
         cleared++;
       }
     }
@@ -88,6 +95,9 @@ class Grid {
       linesCleared += cleared;
       if (level >= 100) {
         victory = true;
+      }
+      if (cleared == 4) {
+        onTetris?.call(List<int>.from(clearedRows));
       }
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,11 +42,13 @@ class _BlocksGamePageState extends State<BlocksGamePage>
     with SingleTickerProviderStateMixin {
   late BlcoksGame game;
   final FocusNode _focusNode = FocusNode();
+  List<int>? _tetrisRows;
 
   @override
   void initState() {
     super.initState();
-    game = BlcoksGame(this, onUpdate: () => setState(() {}));
+    game = BlcoksGame(this,
+        onUpdate: () => setState(() {}), onTetris: _handleTetris);
     game.bind();
   }
 
@@ -59,8 +61,22 @@ class _BlocksGamePageState extends State<BlocksGamePage>
   void _restartGame() {
     game.dispose();
     setState(() {
-      game = BlcoksGame(this, onUpdate: () => setState(() {}));
+      game = BlcoksGame(this,
+          onUpdate: () => setState(() {}), onTetris: _handleTetris);
       // Do NOT call game.bind() or create another ticker
+    });
+  }
+
+  void _handleTetris(List<int> rows) {
+    setState(() {
+      _tetrisRows = rows;
+    });
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) {
+        setState(() {
+          _tetrisRows = null;
+        });
+      }
     });
   }
 
@@ -201,6 +217,7 @@ class _BlocksGamePageState extends State<BlocksGamePage>
                         child: GameBoard(
                           grid: game.grid,
                           blockSize: blockSize,
+                          highlightRows: _tetrisRows,
                         ),
                       ),
                     ),

--- a/lib/ui/game_board.dart
+++ b/lib/ui/game_board.dart
@@ -7,11 +7,13 @@ import '../game/grid.dart';
 class GameBoard extends StatelessWidget {
   final Grid grid;
   final double blockSize;
+  final List<int>? highlightRows;
 
   const GameBoard({
     Key? key,
     required this.grid,
     this.blockSize = 20.0,
+    this.highlightRows,
   }) : super(key: key);
 
   @override
@@ -41,6 +43,27 @@ class GameBoard extends StatelessWidget {
               for (int x = 0; x < grid.currentBlock!.shape[y].length; x++)
                 if (grid.currentBlock!.shape[y][x] == 1)
                   _buildFallingBlock(x, y, blockSize),
+
+          if (highlightRows != null)
+            for (final row in highlightRows!)
+              Positioned(
+                left: 0,
+                top: row * blockSize,
+                child: Container(
+                  width: Grid.columns * blockSize,
+                  height: blockSize,
+                  decoration: BoxDecoration(
+                    color: Colors.orangeAccent.withOpacity(0.6),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Colors.orangeAccent,
+                        blurRadius: 8,
+                        spreadRadius: 2,
+                      )
+                    ],
+                  ),
+                ),
+              ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- trigger callback when 4 lines cleared in `Grid`
- expose tetris callback via `BlcoksGame`
- highlight cleared rows in `GameBoard`
- show a glowing effect for 300ms in main game screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749d4a1e6c8325a6dd1db8487678b4